### PR TITLE
Adding offset, min, and max options to allow for complete collection on keywords using the search function

### DIFF
--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -143,20 +143,20 @@ class Api:
                     
                 ),
             )
-        else:
-            return self._get(
-                "/v2/search",
-                params=dict(
-                    q=query,
-                    resolve=resolve,
-                    limit=limit,
-                    type=searchtype,
-                    offset=offset,
-                    min_id=min_id,
-                    max_id=max_id,
-                ),
-            )
-            
+        
+        return self._get(
+            "/v2/search",
+            params=dict(
+                q=query,
+                resolve=resolve,
+                limit=limit,
+                type=searchtype,
+                offset=offset,
+                min_id=min_id,
+                max_id=max_id,
+            ),
+        )
+        
         
     def trending(self):
         """Return trending truths."""

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -135,7 +135,7 @@ class Api:
                 resolve=resolve,
                 limit=limit,
                 type=searchtype,
-                offset=offset
+                offset=offset,
             ),
         )
 

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -123,6 +123,7 @@ class Api:
         query: str = None,
         limit: int = 4,
         resolve: bool = 4,
+        offset: int=0,
     ) -> Optional[dict]:
         """Search users, statuses or hashtags."""
 
@@ -134,6 +135,7 @@ class Api:
                 resolve=resolve,
                 limit=limit,
                 type=searchtype,
+                offset=offset
             ),
         )
 

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -124,21 +124,40 @@ class Api:
         limit: int = 4,
         resolve: bool = 4,
         offset: int=0,
+        min_id: str='0',
+        max_id: str=None
     ) -> Optional[dict]:
         """Search users, statuses or hashtags."""
 
         assert query is not None and searchtype is not None
-        return self._get(
-            "/v2/search",
-            params=dict(
-                q=query,
-                resolve=resolve,
-                limit=limit,
-                type=searchtype,
-                offset=offset,
-            ),
-        )
-
+        if max_id==None:
+            return self._get(
+                "/v2/search",
+                params=dict(
+                    q=query,
+                    resolve=resolve,
+                    limit=limit,
+                    type=searchtype,
+                    offset=offset,
+                    min_id=min_id,
+                    
+                ),
+            )
+        else:
+            return self._get(
+                "/v2/search",
+                params=dict(
+                    q=query,
+                    resolve=resolve,
+                    limit=limit,
+                    type=searchtype,
+                    offset=offset,
+                    min_id=min_id,
+                    max_id=max_id,
+                ),
+            )
+            
+        
     def trending(self):
         """Return trending truths."""
 


### PR DESCRIPTION
**This is literally by first pull request ever, so be gentle.**

Usage is something like this:

```
min=108789781130656241
gap=100000000000
cycles=100
term='Russia'

search_count=30
page=0
status_list=[]

for cycle in range(0,cycles):
    search_count=30
    page=0
    while search_count>0:
        temp=test_api.search('statuses', term, 40, 4,40*page, str(min+cycle*gap),str(min+(cycle+1)*gap) )['statuses']
        status_list=status_list+temp
        search_count=len(temp)
        page+=1

```