### PR TITLE
Add Ads API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@ Commands:
   suggestions  Pull the list of suggested users.
   tags         Pull trendy tags.
   trends       Pull trendy Truths.
+  ads          Pull ads.
   user         Pull a user's metadata.
 ```

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -152,6 +152,11 @@ class Api:
 
         return self._get(f"/v2/suggestions?limit={maximum}")
 
+    def ads(self, device: str = "desktop") -> dict:
+        """Return a list of ads from Rumble's Ad Platform via Truth Social API."""
+
+        return self._get(f"/v1/truth/ads?device={device}")
+
     def user_followers(
         self,
         user_handle: str = None,

--- a/truthbrush/cli.py
+++ b/truthbrush/cli.py
@@ -63,6 +63,12 @@ def suggestions():
 
 
 @cli.command()
+def ads():
+    """Pull ads."""
+
+    print(json.dumps(api.ads()))
+
+@cli.command()
 @click.argument("handle")
 @click.option("--maximum", help="the maximum number of followers to pull", type=int)
 @click.option(


### PR DESCRIPTION
Pulls ads from the new Rumble Ads platform that is currently integrated in truth social.

More details here:

- https://twitter.com/drewharwell/status/1568319537241796608
- https://www.prnewswire.com/news-releases/truth-social-joins-rumbles-ad-platform-as-first-publisher-301610421.html
- https://www.prnewswire.com/news-releases/rumble-launches-beta-version-of-ad-platform-301609687.html

A sample response:


```json
{
	"count": 20,
	"ads": [{
		"type": 1,
		"impression": "https://truthsocial.com/api/v1/truth/ads/impression/?path={sample_ad_id}",
		"click": "https://a-delivery.rmbl.ws/c?tid={sample_rumble_ad_id}",
		"asset": "https://a-cdn.rmbl.ws/creatives/[xxx].jpg",
		"expires": 1662765579,
		"why_copy": "We show you ads for products and services we think you might like."
	},
```
