### PR TITLE
Re-support use of TRUTHSOCIAL_TOKEN, login if not provided

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truthbrush"
-version = "0.1.2"
+version = "0.1.3"
 description = "API client for Truth Social"
 authors = ["R. Miles McCain <github@sendmiles.email>"]
 license = "Apache 2.0"

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -34,28 +34,28 @@ class LoginErrorException(Exception):
 
 
 class Api:
-    def __init__(self, username: str = None, password: str = None):
+    def __init__(self, username: str = None, password: str = None, token: str = None):
         self.ratelimit_max = 300
         self.ratelimit_remaining = None
         self.ratelimit_reset = None
         self.__username = username
         self.__password = password
-        self.auth_id = ""
+        self.auth_id = token
 
     def __check_login(self):
         """Runs before any login-walled function to check for login credentials and generates an auth ID token"""
-        if self.__username is None:
-            raise LoginErrorException("Username is missing.")
-        if self.__password is None:
-            raise LoginErrorException("Password is missing.")
-        if self.auth_id == "":
+        if self.auth_id is None:
+            if self.__username is None:
+                raise LoginErrorException("Username is missing.")
+            if self.__password is None:
+                raise LoginErrorException("Password is missing.")
             self.auth_id = self.get_auth_id(self.__username, self.__password)
 
     def _make_session(self):
         s = requests.Session()
         s.proxies.update(proxies)
         retries = Retry(
-            total=10,
+            total=5,
             backoff_factor=0.5,
             status_forcelist=[413, 429, 503, 403, 500, 501, 502, 503, 504, 524],
         )

--- a/truthbrush/cli.py
+++ b/truthbrush/cli.py
@@ -9,7 +9,11 @@ from dotenv import load_dotenv
 from .api import Api
 
 load_dotenv()  # take environment variables from .env.
-api = Api(os.getenv("TRUTHSOCIAL_USERNAME"), os.getenv("TRUTHSOCIAL_PASSWORD"))
+api = Api(
+    os.getenv("TRUTHSOCIAL_USERNAME"),
+    os.getenv("TRUTHSOCIAL_PASSWORD"),
+    os.getenv("TRUTHSOCIAL_TOKEN"),
+)
 
 
 @click.group()
@@ -69,6 +73,7 @@ def ads():
     """Pull ads."""
 
     print(json.dumps(api.ads()))
+
 
 @cli.command()
 @click.argument("handle")


### PR DESCRIPTION
Allow passing in the token in cases where it's easier / safer to just store that or to avoid spurious logins.