### PR TITLE
Remove SystemExit raise in api.py

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -3,7 +3,7 @@ from dateutil import parser as date_parse
 
 import pytest
 
-from truthbrush.api import Api
+from truthbrush.api import Api, LoginErrorException
 
 
 @pytest.fixture(scope="module")
@@ -150,3 +150,8 @@ def test_pull_statuses(api):
         "_pulled",
     ]
     assert isinstance(latest["id"], str)
+
+
+def test_get_auth_id_raises_login_error_exception(api):
+    with pytest.raises(LoginErrorException):
+        api.get_auth_id("invalid_username", "invalid_password")

--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -466,7 +466,7 @@ class Api:
             sess_req.raise_for_status()
         except requests.RequestsError as e:
             logger.error(f"Failed login request: {str(e)}")
-            raise SystemExit('Cannot authenticate to .')
+            raise LoginErrorException('Cannot authenticate to .')
 
         if not sess_req.json()["access_token"]:
             raise ValueError("Invalid truthsocial.com credentials provided!")


### PR DESCRIPTION
Remove the SystemExit raise in `truthbrush/api.py` and replace it with `LoginErrorException` since SystemExit prevents from using the function in a TryExcept block.

* Replace `SystemExit` with `LoginErrorException` in the `get_auth_id` function in `truthbrush/api.py`.
* Add a test case in `test/test_api.py` to verify that `get_auth_id` raises `LoginErrorException` on login failure.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stanfordio/truthbrush?shareId=XXXX-XXXX-XXXX-XXXX).