### PR TITLE
Fix type mismatch between post["id"] and since_id 

### DIFF
--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -474,7 +474,7 @@ class Api:
                     tzinfo=timezone.utc
                 )
                 if (created_after and post_at <= created_after) or (
-                    since_id and post["id"] <= since_id
+                    since_id and int(post["id"]) <= int(since_id)
                 ):
                     keep_going = False  # stop the loop, request no more pages
                     break  # do not yeild this post or remaining (older) posts on this page


### PR DESCRIPTION
post["id"] is a string and since_id can be a number, we should make both the same type before comparing.

`pull_statuses` takes number or string for `since_id`, but post["id"] is always a string. The id from truthsocial seems only contain numbers, we should make both integer before comparing.
```
Traceback (most recent call last):
  File "/home/etenal/projects/Moose/moose/agents/truthsocial_agent/services/truthbrush_client.py", line 161, in get_user_statuses
    for post in self.api.pull_statuses(
  File "/home/etenal/projects/Moose/venv/lib/python3.10/site-packages/truthbrush/api.py", line 467, in pull_statuses
    since_id and post["id"] <= since_id
TypeError: '<=' not supported between instances of 'str' and 'int'
```