### PR TITLE
Fix UnboundLocalError in _get when CurlError is raised

### DIFF
--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -140,6 +140,7 @@ class Api:
             )
         except curl_cffi.curl.CurlError as e:
             logger.error(f"Curl error: {e}")
+            return None
 
         # Will also sleep
         self._check_ratelimit(resp)


### PR DESCRIPTION
## Summary

- Fixes an `UnboundLocalError` in `Api._get()` when a `curl_cffi.curl.CurlError` is raised (e.g. `Send failure: Broken pipe`).
- The `except` block logged the error but fell through to code referencing `resp`, which was never assigned due to the exception. Added `return None` to exit early, consistent with the existing error-handling pattern for JSON decode failures.

## Reproduction

```
2026-03-05 14:06:58.425 | ERROR    | truthbrush.api:_get:121 - Curl error: Failed to perform, curl: (55) Send failure: Broken pipe.
[14:07:00] cannot access local variable 'resp' where it is not associated with a value
```

## Fix

Return `None` from the `except CurlError` block so execution doesn't fall through to `self._check_ratelimit(resp)` and `resp.json()` with an unbound variable.


Made with [Cursor](https://cursor.com)