### PR TITLE
Fix search crash and add date bounds to CLI

### DIFF
--- a/truthbrush/api.py
+++ b/truthbrush/api.py
@@ -264,43 +264,32 @@ class Api:
             min_id = str(date_to_bound(start_date, "start"))
         if end_date is not None:
             max_id = str(date_to_bound(end_date, "end"))
-        assert min_id < max_id, "min_id must be less than max_id"
+        if max_id is not None:
+            assert min_id < max_id, "min_id must be less than max_id"
 
-        page = 0
-        while page < limit:
-            if max_id is None:
-                resp = self._get(
-                    "/v2/search",
-                    params=dict(
-                        q=query,
-                        resolve=resolve,
-                        limit=limit,
-                        type=searchtype,
-                        offset=offset,
-                        min_id=min_id,
-                    ),
-                )
+        PAGE_SIZE = 40
+        total_yielded = 0
+        while total_yielded < limit:
+            fetch_size = min(PAGE_SIZE, limit - total_yielded)
+            params = dict(
+                q=query,
+                resolve=resolve,
+                limit=fetch_size,
+                type=searchtype,
+                offset=offset,
+                min_id=min_id,
+            )
+            if max_id is not None:
+                params["max_id"] = max_id
 
-            else:
-                resp = self._get(
-                    "/v2/search",
-                    params=dict(
-                        q=query,
-                        resolve=resolve,
-                        limit=limit,
-                        type=searchtype,
-                        offset=offset,
-                        min_id=min_id,
-                        max_id=max_id,
-                    ),
-                )
+            resp = self._get("/v2/search", params=params)
 
-            offset += 40
-            # added new not sure if helpful
             if not resp or all(value == [] for value in resp.values()):
                 break
 
             yield resp
+            total_yielded += sum(len(v) for v in resp.values() if isinstance(v, list))
+            offset += PAGE_SIZE
 
     def hashtag(
         self,

--- a/truthbrush/cli.py
+++ b/truthbrush/cli.py
@@ -79,10 +79,12 @@ def user(handle: str):
     "--limit", default=40, help="Limit the number of items returned", type=int
 )
 @click.option("--resolve", help="Resolve", type=bool)
-def search(searchtype: str, query: str, limit: int, resolve: bool):
+@click.option("--start-date", default=None, help="Start date for search results (e.g. 2026-01-01)", type=str)
+@click.option("--end-date", default=None, help="End date for search results (e.g. 2026-03-01)", type=str)
+def search(searchtype: str, query: str, limit: int, resolve: bool, start_date: str, end_date: str):
     """Search for users, statuses, groups, or hashtags."""
 
-    for page in api.search(searchtype, query, limit, resolve):
+    for page in api.search(searchtype, query, limit, resolve, start_date=start_date, end_date=end_date):
         print(json.dumps(page[searchtype]))
 
 


### PR DESCRIPTION
## Summary
- Guard `min_id < max_id` assertion for when `max_id` is `None`, which caused search to crash on every call without date bounds
- Add `--start-date` and `--end-date` options to the search CLI command to expose the date bound functionality added in #65
- Fix pagination: `limit` now controls total items returned instead of being used as both page size and page counter (the page counter was also never incremented)

## Context
The assertion added in #65 runs unconditionally, but `max_id` defaults to `None`, so `"0" < None` raises a `TypeError` on every basic search call. The CLI also had no way to pass date bounds, so there was no workaround.

## Test plan
- [x] `truthbrush search --searchtype statuses "query"` no longer crashes
- [x] `truthbrush search --searchtype statuses --start-date 2026-03-23 --end-date 2026-03-24 "query"` returns results within bounds
- [x] `truthbrush search --searchtype statuses --start-date 2026-03-01 --end-date 2026-03-22 "query"` correctly excludes results outside bounds
- [x] `--limit 5` returns 5 results, `--limit 50` returns 50 results